### PR TITLE
Sort multi-line arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,16 @@ WORKDIR /home/dev
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    cmake=3.13.* \
-    libc6-i386=2.30-* \
-    bzip2=1.0.* \
     build-essential=12.8* \
-    doxygen=1.8.* \
-    lcov=1.14-* \
-    graphviz=2.40.* \
-    git=1:2.20.* \
+    bzip2=1.0.* \
     ca-certificates=20190110 \
+    cmake=3.13.* \
     curl=7.65.* \
+    doxygen=1.8.* \
+    git=1:2.20.* \
+    graphviz=2.40.* \
+    lcov=1.14-* \
+    libc6-i386=2.30-* \
     python=2.7.* \
     && rm -rf /var/lib/apt/lists/* \
     && export GCC_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2" \


### PR DESCRIPTION
Whenever possible, ease later changes by sorting multi-line arguments
alphanumerically. This helps to avoid duplication of packages and make
the list much easier to update. This also makes PRs a lot easier to read
and review.